### PR TITLE
Fix log spam

### DIFF
--- a/PluginSolution/PlayerModel.cs
+++ b/PluginSolution/PlayerModel.cs
@@ -234,9 +234,9 @@ namespace ValheimPlayerModels
                             }
                             else
                             {
-                                tries++;
                                 yield return null;
                             }
+                            tries++;
                         } while (string.IsNullOrEmpty(playerId) && tries < 100);
 
                         if (!string.IsNullOrEmpty(playerId))

--- a/PluginSolution/PlayerModel.cs
+++ b/PluginSolution/PlayerModel.cs
@@ -140,10 +140,13 @@ namespace ValheimPlayerModels
 
                 foreach (AttachTransform attachTransform in ogAttachments)
                 {
-                    attachTransform.ogAttach.position = attachTransform.pmAttach.position;
-                    attachTransform.ogAttach.rotation = attachTransform.pmAttach.rotation;
-                    attachTransform.ogAttach.localScale =
-                        Vector3.Scale(attachTransform.ogScale, attachTransform.pmAttach.localScale);
+                    if (attachTransform.pmAttach != null)
+                    {
+                        attachTransform.ogAttach.position = attachTransform.pmAttach.position;
+                        attachTransform.ogAttach.rotation = attachTransform.pmAttach.rotation;
+                        attachTransform.ogAttach.localScale =
+                            Vector3.Scale(attachTransform.ogScale, attachTransform.pmAttach.localScale);
+                    } 
                 }
 
                 if (requestHide)
@@ -231,12 +234,13 @@ namespace ValheimPlayerModels
                             if (playerIndex != -1)
                             {
                                 playerId = playerList[playerIndex].m_host;
+                                tries++;
                             }
                             else
                             {
+                                tries++;
                                 yield return null;
                             }
-                            tries++;
                         } while (string.IsNullOrEmpty(playerId) && tries < 100);
 
                         if (!string.IsNullOrEmpty(playerId))


### PR DESCRIPTION
Added a check to see if the attachTransform in ogAttachments was null, I don't know why this is sometimes null but because it is it was causing the log to get filled with NullReferenceException spam (and also to fail out of LateUpdate).

This is branched off of my open PR so it contains that one.... I can clean this up if you want or we can just work off this one.