### PR TITLE
Fix use of `Valheim/Standard` (`Custom/Player`) shader via soft references

### DIFF
--- a/PluginSolution/Loaders/ValavtrLoader.cs
+++ b/PluginSolution/Loaders/ValavtrLoader.cs
@@ -162,7 +162,11 @@ namespace ValheimPlayerModels.Loaders
         public override void Unload()
         {
             if (avatarBundle) avatarBundle.Unload(true);
-            if (referencedShader) shaderRef.Release();
+            if (referencedShader)
+            {
+                referencedShader = false;
+                shaderRef.Release();
+            }
         }
 
         private bool referencedShader = false;

--- a/PluginSolution/Loaders/ValavtrLoader.cs
+++ b/PluginSolution/Loaders/ValavtrLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using SoftReferenceableAssets;
+using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;
 using UnityEngine;
@@ -8,6 +9,7 @@ namespace ValheimPlayerModels.Loaders
     public class ValavtrLoader : AvatarLoaderBase
     {
         private AssetBundle avatarBundle;
+        private SoftReference<Shader> shaderRef;
 
         public override IEnumerator LoadFile(string file)
         {
@@ -67,7 +69,10 @@ namespace ValheimPlayerModels.Loaders
                 {
                     if (mat && mat.shader.name == "Valheim/Standard")
                     {
-                        mat.shader = Shader.Find("Custom/Player");
+                        if (TryGetPlayerShader(out var shader))
+                        {
+                            mat.shader = shader;
+                        }
 
                         var mainTex = mat.HasProperty("_MainTex") ? mat.GetTexture("_MainTex") as Texture2D : null;
                         var bumpMap = mat.HasProperty("_BumpMap") ? mat.GetTexture("_BumpMap") : null;
@@ -157,6 +162,36 @@ namespace ValheimPlayerModels.Loaders
         public override void Unload()
         {
             if (avatarBundle) avatarBundle.Unload(true);
+            if (referencedShader) shaderRef.Release();
+        }
+
+        private bool referencedShader = false;
+
+        private bool TryGetPlayerShader(out Shader shader) {
+            if (!referencedShader)
+            {
+                Runtime.MakeAllAssetsLoadable();
+                // The asset ID here corresponds to Valheim's "Player" shader.
+                if (AssetID.TryParse("0ddedf6492e674317b18255c4db06013", out AssetID playerShaderAssetID))
+                {
+                    shaderRef = new SoftReference<Shader>(playerShaderAssetID);
+                    shaderRef.Load();
+                    referencedShader = true;
+                    shader = shaderRef.Asset;
+                    return true;
+                }
+                Plugin.Log.LogWarning("Failed to find player shader; unable to swap for Valheim/Standard");
+                shader = null;
+                return false;
+            }
+            else if (shaderRef.IsLoaded) {
+                shader = shaderRef.Asset;
+                return true;
+            }
+
+            Plugin.Log.LogError("Shader referenced but not loaded? Something is wrong.");
+            shader = null;
+            return false;
         }
     }
 }

--- a/PluginSolution/Loaders/ValavtrLoader.cs
+++ b/PluginSolution/Loaders/ValavtrLoader.cs
@@ -174,7 +174,6 @@ namespace ValheimPlayerModels.Loaders
         private bool TryGetPlayerShader(out Shader shader) {
             if (!referencedShader)
             {
-                Runtime.MakeAllAssetsLoadable();
                 // The asset ID here corresponds to Valheim's "Player" shader.
                 if (AssetID.TryParse("0ddedf6492e674317b18255c4db06013", out AssetID playerShaderAssetID))
                 {

--- a/PluginSolution/PlayerModelPatches.cs
+++ b/PluginSolution/PlayerModelPatches.cs
@@ -139,5 +139,13 @@ namespace ValheimPlayerModels
             }
         }
     }
+
+    [HarmonyPatch(typeof(EntryPointSceneLoader), nameof(EntryPointSceneLoader.Start))]
+    static class Patch_All_SoftReferenceableAssets {
+        [HarmonyPrefix]
+        static void Prefix() {
+            SoftReferenceableAssets.Runtime.MakeAllAssetsLoadable();
+        }
+    }
 }
 #endif

--- a/PluginSolution/ValheimPlayerModels.csproj
+++ b/PluginSolution/ValheimPlayerModels.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
@@ -46,6 +46,7 @@
   <ItemGroup Condition="'$(GameDir)' != '' and '$(PublicizeLocally)' == 'true'">
     <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" />
     <Reference Include="$(GameDir)\valheim_Data\Managed\assembly_*.dll" IncludeAssets="compile" Publicize="true"/>
+    <Reference Include="$(GameDir)\valheim_Data\Managed\SoftReferenceableAssets.dll" IncludeAssets="compile" Publicize="true"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">


### PR DESCRIPTION
Alternative to #12, instead making use of the soft-reference functionality.

---

Built artifact/DLL here: [ValheimPlayerModels.zip](https://github.com/user-attachments/files/18665749/ValheimPlayerModels.zip)

<details>

<summary>Paranoia things</summary>

Much the same rigamarole I had in https://github.com/Ikeiwa/ValheimPlayerModels/pull/10#issuecomment-1596214205

[ValheimPlayerModels.zip.sig.txt](https://github.com/user-attachments/files/18665757/ValheimPlayerModels.zip.sig.txt)

```bash
$ sha512sum.exe -b ValheimPlayerModels.zip ValheimPlayerModels.dll ValheimPlayerModels.dll.sig ValheimPlayerModels.zip.sig.txt
597c4c7d4b5112bc791ee47d7f130fbdff85fe7c4e6fe22b212f04313faad0e681499a90b7d56e89f1dfe488935bfdab74b0db6f561b34a0fa4f46549e6ae35d *ValheimPlayerModels.zip
98a98ac7305b7e57ec93bef7947b1b9df1b0e98cf50a081bb2ca660c0261d385c1ac2564b809aa9e158bf51c42da1a492a662c86496f3ed20bc3595b437e4af7 *ValheimPlayerModels.dll
3b89fb33376a5649970605bdbd2bc62294e535d7dcbc550b4d9f15739d6f14670ab3416c6d8657c5e3cdb6ca5fc93ca921daeca9521e18b295d116af9600bfdd *ValheimPlayerModels.dll.sig
68a747f5e6022ce85255674fba445ac5487e1b9fb3f2cefd33c3564b7b6b47df5c00dd7bab087ab84b5a6e0ececd2ea82ef1e179679a0e0b0255fbe46ae77c6b *ValheimPlayerModels.zip.sig.txt
```

Signing's been done with my present Github SSH key. The public key of the pair used for signing can be obtained from https://api.github.com/users/dresklaw/ssh_signing_keys , specifically, `122361`.

Should be able to verify the couple of signatures with something like:

```
$ ssh-keygen.exe -Y check-novalidate -n file -f ~/.ssh/id_rsa.pub -s ValheimPlayerModels.zip.sig.txt < ValheimPlayerModels.zip
Good "file" signature with RSA key SHA256:tkXg1meWn04n0hDJeSTJJcOSFDB2+kZYAVjZUrqCyxU
```

and after extracting the DLL:

```
$ ssh-keygen.exe -Y check-novalidate -n file -f ~/.ssh/id_rsa.pub -s ValheimPlayerModels.dll.sig < ValheimPlayerModels.dll
Good "file" signature with RSA key SHA256:tkXg1meWn04n0hDJeSTJJcOSFDB2+kZYAVjZUrqCyxU
```

with `~/.ssh/id_rsa.pub` being the path instead of wherever my public key was placed.

... shrug?

</details>